### PR TITLE
Added locale support

### DIFF
--- a/src/FetchBelgianTrainsCommand.php
+++ b/src/FetchBelgianTrainsCommand.php
@@ -14,9 +14,11 @@ class FetchBelgianTrainsCommand extends Command
     {
         $this->info('Fetching trainConnections from iRail...');
 
+        $locale = config('dashboard.tiles.belgian_trains.locale') ?? 'nl';
+
         $trainConnections = collect(config('dashboard.tiles.belgian_trains.connections') ?? [])
-            ->map(function (array $connection) use ($iRail) {
-                $trains = $iRail->getConnections($connection['departure'], $connection['destination']);
+            ->map(function (array $connection) use ($locale, $iRail) {
+                $trains = $iRail->getConnections($connection['departure'], $connection['destination'], $locale);
 
                 return ['label' => $connection['label'], 'trains' => $trains];
             })

--- a/src/IRailApi.php
+++ b/src/IRailApi.php
@@ -6,9 +6,9 @@ use Illuminate\Support\Facades\Http;
 
 class IRailApi
 {
-    public function getConnections(string $departureStationName, string $destinationStationName): array
+    public function getConnections(string $departureStationName, string $destinationStationName, string $locale): array
     {
-        $endpoint = "https://api.irail.be/connections?from={$departureStationName}&to={$destinationStationName}&format=json&lang=nl";
+        $endpoint = "https://api.irail.be/connections?from={$departureStationName}&to={$destinationStationName}&format=json&lang={$locale}";
 
         $response = Http::get($endpoint)->json();
 


### PR DESCRIPTION
I added locale support by changing the lang parameter on the iRail API.

As you can see, there's very few changes in the code.
User can set the locale in the config : 
```php
'belgian_trains' => [
    'locale' => 'fr',
],
```

If locale is not set, it defaults to 'nl'.

Thanks for your great work on the dashboard !