### PR TITLE
Fix train times rendering as UTC instead of app timezone

### DIFF
--- a/resources/views/tile.blade.php
+++ b/resources/views/tile.blade.php
@@ -32,7 +32,7 @@
                                     @endif
 
                                     <span class="flex-none font-bold text-right variant-tabular">
-                                        {{ \Carbon\Carbon::createFromTimestamp($train['time'])->format('H:i') }}
+                                        {{ \Carbon\Carbon::createFromTimestamp($train['time'], config('app.timezone'))->format('H:i') }}
                                     </span>
                                 </li>
                             @endif


### PR DESCRIPTION
## Summary

`Carbon::createFromTimestamp($ts)` without a timezone argument returns a UTC instance in Carbon 3.x, regardless of `date_default_timezone_get()` or `config('app.timezone')`. As a result, train departure times in the tile render as UTC for every installation — e.g. a train leaving at 13:35 Brussels time shows as 11:35.

This passes `config('app.timezone')` as the second argument so times render in the app's configured timezone.

## Test plan

- [ ] Run the tile on an app with `'timezone' => 'Europe/Brussels'` and confirm times match the iRail/Belgian Railways schedule.
- [ ] Run the tile on an app with `'timezone' => 'UTC'` and confirm behavior is unchanged.